### PR TITLE
Bitcoin-backed-Lending-Protocol

### DIFF
--- a/Bitcoin-backed-Lending-Protocol/contracts/Bitcoin-backed-Lending-Protocol.clar
+++ b/Bitcoin-backed-Lending-Protocol/contracts/Bitcoin-backed-Lending-Protocol.clar
@@ -71,5 +71,20 @@
     (default-to u0 (map-get? oracle-prices asset-symbol))
 )
 
+(define-private (get-position-collateral-value (position {
+        collateral-asset: (string-ascii 10),
+        collateral-amount: uint,
+        borrow-asset: (string-ascii 10),
+        borrow-amount: uint,
+        interest-index: uint,
+        timestamp: uint
+    }))
+    (let (
+        (collateral-price (get-asset-price (get collateral-asset position)))
+        (collateral-amount (get collateral-amount position))
+    )
+    (/ (* collateral-amount collateral-price) u1000000))
+)
+
 
 

--- a/Bitcoin-backed-Lending-Protocol/contracts/Bitcoin-backed-Lending-Protocol.clar
+++ b/Bitcoin-backed-Lending-Protocol/contracts/Bitcoin-backed-Lending-Protocol.clar
@@ -43,5 +43,24 @@
     }
 )
 
+(define-map user-position-ids 
+    principal 
+    (list 100 uint)
+)
+
+(define-data-var next-position-id uint u1)
+
+;; Governance parameters
+(define-map asset-params 
+    (string-ascii 10)
+    {
+        collateral-factor: uint,
+        liquidation-threshold: uint,
+        liquidation-penalty: uint,
+        borrow-enabled: bool,
+        deposit-enabled: bool
+    }
+)
+
 
 

--- a/Bitcoin-backed-Lending-Protocol/contracts/Bitcoin-backed-Lending-Protocol.clar
+++ b/Bitcoin-backed-Lending-Protocol/contracts/Bitcoin-backed-Lending-Protocol.clar
@@ -118,4 +118,35 @@
         (/ (* collateral-value u100) borrow-value)))
 )
 
+(define-private (is-position-healthy (position {
+        collateral-asset: (string-ascii 10),
+        collateral-amount: uint,
+        borrow-asset: (string-ascii 10),
+        borrow-amount: uint,
+        interest-index: uint,
+        timestamp: uint
+    }))
+    (>= (get-collateral-ratio position) MIN-COLLATERAL-RATIO)
+)
+
+(define-private (is-position-liquidatable (position {
+        collateral-asset: (string-ascii 10),
+        collateral-amount: uint,
+        borrow-asset: (string-ascii 10),
+        borrow-amount: uint,
+        interest-index: uint,
+        timestamp: uint
+    }))
+    (let (
+        (params (default-to {
+            collateral-factor: u750,
+            liquidation-threshold: LIQUIDATION-THRESHOLD,
+            liquidation-penalty: LIQUIDATION-PENALTY,
+            borrow-enabled: true,
+            deposit-enabled: true
+        } (map-get? asset-params (get collateral-asset position))))
+        (liquidation-threshold (get liquidation-threshold params))
+    )
+    (< (get-collateral-ratio position) liquidation-threshold))
+)
 

--- a/Bitcoin-backed-Lending-Protocol/contracts/Bitcoin-backed-Lending-Protocol.clar
+++ b/Bitcoin-backed-Lending-Protocol/contracts/Bitcoin-backed-Lending-Protocol.clar
@@ -62,5 +62,14 @@
     }
 )
 
+;; Helper functions
+(define-private (is-asset-supported (asset-symbol (string-ascii 10)))
+    (default-to false (map-get? supported-assets asset-symbol))
+)
+
+(define-private (get-asset-price (asset-symbol (string-ascii 10)))
+    (default-to u0 (map-get? oracle-prices asset-symbol))
+)
+
 
 

--- a/Bitcoin-backed-Lending-Protocol/contracts/Bitcoin-backed-Lending-Protocol.clar
+++ b/Bitcoin-backed-Lending-Protocol/contracts/Bitcoin-backed-Lending-Protocol.clar
@@ -21,5 +21,27 @@
 (define-constant OPTIMAL-UTILIZATION u800) ;; 80% optimal utilization rate
 (define-constant SECONDS-PER-YEAR u31536000) ;; Seconds in a year for interest calculations
 
+;; Data maps for protocol state
+(define-map supported-assets (string-ascii 10) bool)
+(define-map oracle-prices (string-ascii 10) uint)
+(define-map asset-pools (string-ascii 10) {
+    total-deposits: uint,
+    total-borrows: uint,
+    last-update-time: uint
+})
+
+;; Loan positions
+(define-map loan-positions 
+    { owner: principal, position-id: uint }
+    {
+        collateral-asset: (string-ascii 10),
+        collateral-amount: uint,
+        borrow-asset: (string-ascii 10),
+        borrow-amount: uint,
+        interest-index: uint,
+        timestamp: uint
+    }
+)
+
 
 

--- a/Bitcoin-backed-Lending-Protocol/contracts/Bitcoin-backed-Lending-Protocol.clar
+++ b/Bitcoin-backed-Lending-Protocol/contracts/Bitcoin-backed-Lending-Protocol.clar
@@ -86,5 +86,36 @@
     (/ (* collateral-amount collateral-price) u1000000))
 )
 
+(define-private (get-position-borrow-value (position {
+        collateral-asset: (string-ascii 10),
+        collateral-amount: uint,
+        borrow-asset: (string-ascii 10),
+        borrow-amount: uint,
+        interest-index: uint,
+        timestamp: uint
+    }))
+    (let (
+        (borrow-price (get-asset-price (get borrow-asset position)))
+        (borrow-amount (get borrow-amount position))
+    )
+    (/ (* borrow-amount borrow-price) u1000000))
+)
+
+(define-private (get-collateral-ratio (position {
+        collateral-asset: (string-ascii 10),
+        collateral-amount: uint,
+        borrow-asset: (string-ascii 10),
+        borrow-amount: uint,
+        interest-index: uint,
+        timestamp: uint
+    }))
+    (let (
+        (collateral-value (get-position-collateral-value position))
+        (borrow-value (get-position-borrow-value position))
+    )
+    (if (is-eq borrow-value u0)
+        u0
+        (/ (* collateral-value u100) borrow-value)))
+)
 
 

--- a/Bitcoin-backed-Lending-Protocol/contracts/Bitcoin-backed-Lending-Protocol.clar
+++ b/Bitcoin-backed-Lending-Protocol/contracts/Bitcoin-backed-Lending-Protocol.clar
@@ -1,3 +1,25 @@
+;; Error codes
+(define-constant ERR-NOT-AUTHORIZED (err u100))
+(define-constant ERR-INSUFFICIENT-COLLATERAL (err u101))
+(define-constant ERR-BELOW-MIN-COLLATERAL-RATIO (err u102))
+(define-constant ERR-INSUFFICIENT-LIQUIDITY (err u103))
+(define-constant ERR-INVALID-AMOUNT (err u104))
+(define-constant ERR-POSITION-NOT-FOUND (err u105))
+(define-constant ERR-NO-POSITION-TO-LIQUIDATE (err u106))
+(define-constant ERR-LIQUIDATION-THRESHOLD-NOT-REACHED (err u107))
+(define-constant ERR-ASSET-NOT-SUPPORTED (err u108))
+
+;; Constants
+(define-constant CONTRACT-OWNER tx-sender)
+(define-constant MIN-COLLATERAL-RATIO u150) ;; 150% minimum collateral ratio
+(define-constant LIQUIDATION-THRESHOLD u130) ;; 130% liquidation threshold
+(define-constant LIQUIDATION-PENALTY u10) ;; 10% liquidation penalty
+(define-constant ORIGINATION-FEE u1) ;; 0.1% origination fee (basis points)
+(define-constant INTEREST-RATE-BASE u1000) ;; Base interest rate (basis points per year)
+(define-constant INTEREST-RATE-SLOPE1 u2000) ;; Interest rate slope 1 (basis points per year)
+(define-constant INTEREST-RATE-SLOPE2 u5000) ;; Interest rate slope 2 (basis points per year)
+(define-constant OPTIMAL-UTILIZATION u800) ;; 80% optimal utilization rate
+(define-constant SECONDS-PER-YEAR u31536000) ;; Seconds in a year for interest calculations
 
 
 


### PR DESCRIPTION
## 📦 Pull Request: Protocol Constants, Errors & Core Read-Only Functions

### ✨ Summary

This PR introduces foundational constants, error codes, protocol state mappings, helper functions, and key read-only functions necessary for a lending and borrowing protocol. These definitions establish a solid groundwork for future smart contract development related to collateralized debt positions, interest calculations, and liquidation logic.
### 🧱 Changes Included

#### 🔐 Error Codes
Defined a set of reusable error constants to standardize failure responses:
- `ERR-NOT-AUTHORIZED (u100)`
- `ERR-INSUFFICIENT-COLLATERAL (u101)`
- `ERR-BELOW-MIN-COLLATERAL-RATIO (u102)`
- `ERR-INSUFFICIENT-LIQUIDITY (u103)`
- `ERR-INVALID-AMOUNT (u104)`
- `ERR-POSITION-NOT-FOUND (u105)`
- `ERR-NO-POSITION-TO-LIQUIDATE (u106)`
- `ERR-LIQUIDATION-THRESHOLD-NOT-REACHED (u107)`
- `ERR-ASSET-NOT-SUPPORTED (u108)`

#### 🧮 Constants
Added protocol-wide constants including:
- Collateral ratio thresholds
- Liquidation penalty
- Interest rate configurations
- Time constants for calculations

#### 🗺 Protocol State Maps
Initialized key storage structures:
- `supported-assets`, `oracle-prices`, and `asset-pools` for market data
- `loan-positions` and `user-position-ids` for tracking debt positions
- `asset-params` for per-asset governance configuration

#### 🛠 Helper Functions
Implemented internal logic for:
- Asset support verification
- Price fetching
- Collateral & borrow value calculations
- Health checks and liquidation status

#### 📖 Read-only Functions
Public functions to retrieve:
- Collateral ratio for a position
- Max borrowable amount based on collateral
- User position IDs
- Asset deposit and borrow totals

### 📌 Notes

- The logic assumes prices are in fixed-point with 6 decimal places (e.g., u1000000 = 1.0).
- Default values are used for safety in absence of mappings (e.g., empty positions or asset params).
- No mutation or side-effecting logic is included in this PR; all functions are view-only or constants.
